### PR TITLE
Modal component to display add to calendar

### DIFF
--- a/Components/Modal/calendar.tsx
+++ b/Components/Modal/calendar.tsx
@@ -13,17 +13,16 @@ type KeyPress = {
  * @description get the diameter of the circle
  * @param {Boolean} active is the modal active?
  */
-const diameter = (active: Boolean) => active? `300vmax`: "132px"
+const diameter = (active: Boolean) => active? `300vmax`: "66px"
 
 
 const CalendarButton = styled.button<CalendarProps>`
-  position: fixed;
+  position: absolute;
   overflow: hidden;
   right: 0px; 
   top: 0px; 
-  transform: translate(50%, -50%);
   bottom: 0%;  
-  border-radius: 50%;
+  border-bottom-left-radius: 100%;
   width: ${(props) => diameter(props.active)}; 
   height: ${(props) => diameter(props.active)}; 
   background: ${Theme.colors.purpleBase};
@@ -42,7 +41,7 @@ const CalendarButton = styled.button<CalendarProps>`
 
 /** @description Style for the close button (it is a div because buttons have to many styles) */
 const StyledClose = styled.button<CalendarProps>`
-  position: fixed;
+  position: absolute;
   opacity: ${(props) => props.active? '1': '0'};
   background: rgba(0,0,0,0) ;
   width: 25px;
@@ -71,7 +70,7 @@ const StyledClose = styled.button<CalendarProps>`
 
 /**@description this is the style for the container of the content in the modal have some delay in transitions  */
 const Content = styled.div<CalendarProps>`
-  position: fixed;
+  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -81,7 +80,7 @@ const Content = styled.div<CalendarProps>`
 
 /** @description style for de icon this section have some delay in transitions */
 const IconContainer = styled.div<CalendarProps>`
-  position: fixed;
+  position: absolute;
   width: ${(props) => props.active? '25vmin;': '30px'};
   top: ${(props) => props.active? '50%;': '25px'};
   right: ${(props) => props.active? '50%;': '25px'};

--- a/Components/Modal/calendar.tsx
+++ b/Components/Modal/calendar.tsx
@@ -39,6 +39,7 @@ const CalendarButton = styled.button<CalendarProps>`
   
 `
 
+
 /** @description Style for the close button (it is a div because buttons have to many styles) */
 const StyledClose = styled.button<CalendarProps>`
   position: absolute;
@@ -107,6 +108,13 @@ active = false => icon have delay and content fade out faster
 // margin-bottom: 20px;
 // `
 
+
+const ModalContainer = styled.div`
+  position: relative;
+  overflow-x: hidden;
+  overflow-y: hidden;
+`
+
 /** @description this is the modal to display the calendar button, the children's are displayed inside a div centered in the screen */
 const ModalCalendar: React.FC = ({ children }) => {
   const [active, setActive] = useState(false);
@@ -139,4 +147,4 @@ const ModalCalendar: React.FC = ({ children }) => {
   </Content>
   </>)
 };
-export default ModalCalendar
+export {ModalCalendar, ModalContainer}

--- a/Components/Modal/calendar.tsx
+++ b/Components/Modal/calendar.tsx
@@ -10,11 +10,6 @@ type KeyPress = {
 }
 
 /**
- * @description get the position of the circle
- * @param {Boolean} active is the modal active?
- */
-const position = (active: Boolean) => active? `-150vmax`: "-66px"
-/**
  * @description get the diameter of the circle
  * @param {Boolean} active is the modal active?
  */
@@ -24,8 +19,9 @@ const diameter = (active: Boolean) => active? `300vmax`: "132px"
 const StyledButton = styled.div<CalendarProps>`
   position: fixed;
   overflow: hidden;
-  right: ${(props) => position(props.active)}; 
-  top: ${(props) => position(props.active)}; 
+  right: 0px; 
+  top: 0px; 
+  transform: translate(50%, -50%);
   bottom: 0%;  
   border-radius: 50%;
   width: ${(props) => diameter(props.active)}; 
@@ -38,11 +34,12 @@ const StyledButton = styled.div<CalendarProps>`
 /** @description Style for the close button (it is a div because buttons have to many styles) */
 const StyledClose = styled.div<CalendarProps>`
   position: fixed;
-  width: ${(props) => props.active? '25px': '0px'};
-  height: ${(props) => props.active? '25px': '0px'};
+  opacity: ${(props) => props.active? '1': '0'};
+  width: 25px;
+  height: 25px;
   right: 10px;
   top: 10px;
-  border: ${(props) => props.active? '2px solid': '0px'};
+  border: 2px solid;
   border-color: #fff;
   cursor: pointer;
   border-radius: 50%;
@@ -51,7 +48,7 @@ const StyledClose = styled.div<CalendarProps>`
   vertical-align: middle;
   & span { 
     transition: 2s;
-    font-size: ${(props) => props.active? '1em;': '0px'};
+    font-size: 1em;
     color: #FFF;
     margin: auto;
     text-align: center;
@@ -71,15 +68,16 @@ const Content = styled.div<CalendarProps>`
 /** @description style for de icon this section have some delay in transitions */
 const IconContainer = styled.div<CalendarProps>`
   position: fixed;
-  width: ${(props) => props.active? '25vw;': '30px'};
+  width: ${(props) => props.active? '25vmin;': '30px'};
   top: ${(props) => props.active? '50%;': '25px'};
   right: ${(props) => props.active? '50%;': '25px'};
   transform: translate(50%, -50%);
   opacity: ${(props) => props.active? '0': '1'};
   transition-delay: 5s;
+  cursor: pointer;
   transition:${(props) => props.active? '2s': '1.5s 0.5s'}; 
   & svg {
-    fill: ${(props) => props.active? '#AAA': '#FFF'};
+    fill: ${(props) => props.active? '#CCC': '#FFF'};
   }
 `
 /* content and iconContainer have delay in layout 
@@ -112,18 +110,21 @@ const ModalCalendar: React.FC = ({ children }) => {
       return document.removeEventListener("keydown", (e) =>log(e), false);
     }
   },[])
-  return <StyledButton onClick={() => {if(!active) open()}} active={active}>
-          <StyledClose onClick={() => close()} active={active} >
-            <span>X</span>
-          </StyledClose>
-          <IconContainer active={active}>
-            {/* this is the svg of the calendar */}
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M1 4c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4zm2 2v12h14V6H3zm2-6h2v2H5V0zm8 0h2v2h-2V0zM5 9h2v2H5V9zm0 4h2v2H5v-2zm4-4h2v2H9V9zm0 4h2v2H9v-2zm4-4h2v2h-2V9zm0 4h2v2h-2v-2z"/></svg>
-          </IconContainer>
-          <Content active={active} > 
-            { children }
-            {/* {[1,2,3,4].map((i) => <Line key={i}> hola </Line>)} */}
-          </Content>
-        </StyledButton>;
+  return (
+  <> 
+  <StyledButton onClick={() => {if(!active) open()}} active={active}>
+  </StyledButton>;
+  <StyledClose onClick={() => close()} active={active} >
+    <span>X</span>
+  </StyledClose>
+  <IconContainer active={active} onClick={() => {if(!active) open()}}>
+    {/* this is the svg of the calendar */}
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M1 4c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4zm2 2v12h14V6H3zm2-6h2v2H5V0zm8 0h2v2h-2V0zM5 9h2v2H5V9zm0 4h2v2H5v-2zm4-4h2v2H9V9zm0 4h2v2H9v-2zm4-4h2v2h-2V9zm0 4h2v2h-2v-2z"/></svg>
+  </IconContainer>
+  <Content active={active} > 
+    { children }
+    {/* {[1,2,3,4].map((i) => <Line key={i}> hola </Line>)} */}
+  </Content>
+  </>)
 };
 export default ModalCalendar

--- a/Components/Modal/calendar.tsx
+++ b/Components/Modal/calendar.tsx
@@ -16,7 +16,7 @@ type KeyPress = {
 const diameter = (active: Boolean) => active? `300vmax`: "132px"
 
 
-const StyledButton = styled.div<CalendarProps>`
+const CalendarButton = styled.button<CalendarProps>`
   position: fixed;
   overflow: hidden;
   right: 0px; 
@@ -29,12 +29,22 @@ const StyledButton = styled.div<CalendarProps>`
   background: ${Theme.colors.purpleBase};
   cursor:${(props) => props.active? 'default': 'pointer'};
   transition: 2s;
+  border-color: #fff;
+  border: 0;
+  & :focus {
+    outline: 0px;
+    border: 3px;
+    border-color: #CCC;
+    border-style: solid;
+  }
+  
 `
 
 /** @description Style for the close button (it is a div because buttons have to many styles) */
-const StyledClose = styled.div<CalendarProps>`
+const StyledClose = styled.button<CalendarProps>`
   position: fixed;
   opacity: ${(props) => props.active? '1': '0'};
+  background: rgba(0,0,0,0) ;
   width: 25px;
   height: 25px;
   right: 10px;
@@ -46,6 +56,10 @@ const StyledClose = styled.div<CalendarProps>`
   transition: 2s;
   display:flex;
   vertical-align: middle;
+  & :focus {
+    outline:0px;
+    border-color: #CCC;
+  }
   & span { 
     transition: 2s;
     font-size: 1em;
@@ -112,8 +126,7 @@ const ModalCalendar: React.FC = ({ children }) => {
   },[])
   return (
   <> 
-  <StyledButton onClick={() => {if(!active) open()}} active={active}>
-  </StyledButton>;
+  <CalendarButton onClick={() => {if(!active) open()}} active={active} />
   <StyledClose onClick={() => close()} active={active} >
     <span>X</span>
   </StyledClose>

--- a/Components/Modal/calendar.tsx
+++ b/Components/Modal/calendar.tsx
@@ -1,0 +1,129 @@
+import React, {useState, useEffect} from "react";
+import styled from "styled-components";
+import { Theme } from "../../styles/theme";
+
+type CalendarProps = {
+  active:Boolean,
+}
+type KeyPress = {
+  code:String,
+}
+
+/**
+ * @description get the position of the circle
+ * @param {Boolean} active is the modal active?
+ */
+const position = (active: Boolean) => active? `-150vmax`: "-66px"
+/**
+ * @description get the diameter of the circle
+ * @param {Boolean} active is the modal active?
+ */
+const diameter = (active: Boolean) => active? `300vmax`: "132px"
+
+
+const StyledButton = styled.div<CalendarProps>`
+  position: fixed;
+  overflow: hidden;
+  right: ${(props) => position(props.active)}; 
+  top: ${(props) => position(props.active)}; 
+  bottom: 0%;  
+  border-radius: 50%;
+  width: ${(props) => diameter(props.active)}; 
+  height: ${(props) => diameter(props.active)}; 
+  background: ${Theme.colors.purpleBase};
+  cursor:${(props) => props.active? 'default': 'pointer'};
+  transition: 2s;
+`
+
+/** @description Style for the close button (it is a div because buttons have to many styles) */
+const StyledClose = styled.div<CalendarProps>`
+  position: fixed;
+  width: ${(props) => props.active? '25px': '0px'};
+  height: ${(props) => props.active? '25px': '0px'};
+  right: 10px;
+  top: 10px;
+  border: ${(props) => props.active? '2px solid': '0px'};
+  border-color: #fff;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: 2s;
+  display:flex;
+  vertical-align: middle;
+  & span { 
+    transition: 2s;
+    font-size: ${(props) => props.active? '1em;': '0px'};
+    color: #FFF;
+    margin: auto;
+    text-align: center;
+  }
+`
+
+/**@description this is the style for the container of the content in the modal have some delay in transitions  */
+const Content = styled.div<CalendarProps>`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: ${(props) => props.active? '1;': '0'};
+  transition:${(props) => props.active? '2s 1.5s': '0.5s'}; 
+`
+
+/** @description style for de icon this section have some delay in transitions */
+const IconContainer = styled.div<CalendarProps>`
+  position: fixed;
+  width: ${(props) => props.active? '25vw;': '30px'};
+  top: ${(props) => props.active? '50%;': '25px'};
+  right: ${(props) => props.active? '50%;': '25px'};
+  transform: translate(50%, -50%);
+  opacity: ${(props) => props.active? '0': '1'};
+  transition-delay: 5s;
+  transition:${(props) => props.active? '2s': '1.5s 0.5s'}; 
+  & svg {
+    fill: ${(props) => props.active? '#AAA': '#FFF'};
+  }
+`
+/* content and iconContainer have delay in layout 
+
+active = true => content have delay
+active = false => icon have delay and content fade out faster
+*/
+
+// this is for test only
+// const Line = styled.div`
+// width:400px;
+// height: 30px;
+// background: #fff;
+// margin-bottom: 20px;
+// `
+
+/** @description this is the modal to display the calendar button, the children's are displayed inside a div centered in the screen */
+const ModalCalendar: React.FC = ({ children }) => {
+  const [active, setActive] = useState(false);
+  const close = () => setActive(false);
+  const open = () => setActive(true);
+  const log = (e:KeyPress) => {
+    /* support close on Escape press */
+    if(e.code === "Escape") close()
+  }
+  useEffect(()=>{
+    if (process.browser) {
+      // client-side-only code
+      document.addEventListener("keydown",(e) =>log(e), false);
+      return document.removeEventListener("keydown", (e) =>log(e), false);
+    }
+  },[])
+  return <StyledButton onClick={() => {if(!active) open()}} active={active}>
+          <StyledClose onClick={() => close()} active={active} >
+            <span>X</span>
+          </StyledClose>
+          <IconContainer active={active}>
+            {/* this is the svg of the calendar */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M1 4c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4zm2 2v12h14V6H3zm2-6h2v2H5V0zm8 0h2v2h-2V0zM5 9h2v2H5V9zm0 4h2v2H5v-2zm4-4h2v2H9V9zm0 4h2v2H9v-2zm4-4h2v2h-2V9zm0 4h2v2h-2v-2z"/></svg>
+          </IconContainer>
+          <Content active={active} > 
+            { children }
+            {/* {[1,2,3,4].map((i) => <Line key={i}> hola </Line>)} */}
+          </Content>
+        </StyledButton>;
+};
+export default ModalCalendar

--- a/Components/Modal/index.tsx
+++ b/Components/Modal/index.tsx
@@ -1,0 +1,3 @@
+import ModalCalendar from './calendar'
+
+export {ModalCalendar}

--- a/Components/Modal/index.tsx
+++ b/Components/Modal/index.tsx
@@ -1,3 +1,3 @@
-import ModalCalendar from './calendar'
+import {ModalCalendar, ModalContainer} from './calendar'
 
-export {ModalCalendar}
+export {ModalCalendar, ModalContainer}

--- a/Features/Home/elements.ts
+++ b/Features/Home/elements.ts
@@ -13,7 +13,10 @@ export const PageTitle = styled.h1`
 `;
 
 export const Panel = styled.section`
+  position: relative;
   align-items: flex-start;
+  overflow-x: hidden;
+  overflow-y: hidden;
   display: flex;
   width: 100%;
   max-width: 1024px;

--- a/Features/Home/elements.ts
+++ b/Features/Home/elements.ts
@@ -13,10 +13,8 @@ export const PageTitle = styled.h1`
 `;
 
 export const Panel = styled.section`
-  position: relative;
+
   align-items: flex-start;
-  overflow-x: hidden;
-  overflow-y: hidden;
   display: flex;
   width: 100%;
   max-width: 1024px;

--- a/Features/Home/index.tsx
+++ b/Features/Home/index.tsx
@@ -8,6 +8,7 @@ import {
   Link,
   ButtonWrapper,
 } from "./elements";
+import { ModalCalendar } from "../../Components/Modal";
 
 const Title: React.FC<{
   time?: Date;
@@ -23,6 +24,7 @@ export const Home: React.FC<{
     <>
       <PageTitle>¿Cuándo es el Live?</PageTitle>
       <Panel>
+        <ModalCalendar/>
         <Title time={time} />
         <PanelText>{title}</PanelText>
         <Link href="https://noders.live">https://noders.live</Link>

--- a/Features/Home/index.tsx
+++ b/Features/Home/index.tsx
@@ -8,7 +8,7 @@ import {
   Link,
   ButtonWrapper,
 } from "./elements";
-import { ModalCalendar } from "../../Components/Modal";
+import { ModalCalendar, ModalContainer } from "../../Components/Modal";
 
 const Title: React.FC<{
   time?: Date;
@@ -23,15 +23,20 @@ export const Home: React.FC<{
   return (
     <>
       <PageTitle>¿Cuándo es el Live?</PageTitle>
-      <Panel>
-        <ModalCalendar/>
-        <Title time={time} />
-        <PanelText>{title}</PanelText>
-        <Link href="https://noders.live">https://noders.live</Link>
-      </Panel>
+      
+        <Panel>
+          <Title time={time} />
+          <PanelText>{title}</PanelText>
+          <Link href="https://noders.live">https://noders.live</Link>
+        </Panel>
       <ButtonWrapper>
         <Button>Mas eventos</Button>
       </ButtonWrapper>
+      <ModalContainer>
+        <div style={{width:'100%', height:'400px', border:'2px solid black'}}>
+        </div>
+        <ModalCalendar/>
+      </ModalContainer>
     </>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,11 @@
 import { Home } from "../Features/Home";
 import { Page } from "../Components/Page";
+import { ModalCalendar } from "../Components/Modal";
 
 export default () => {
   return (
     <Page>
+      <ModalCalendar/>
       <Home title="30 días de react - “Estilando nuestros pokemones con CSS in JS”" />
     </Page>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,9 @@
 import { Home } from "../Features/Home";
 import { Page } from "../Components/Page";
-import { ModalCalendar } from "../Components/Modal";
 
 export default () => {
   return (
     <Page>
-      <ModalCalendar/>
       <Home title="30 días de react - “Estilando nuestros pokemones con CSS in JS”" />
     </Page>
   );


### PR DESCRIPTION
no se que convención de nombres quieren usar al final le puse modal aunque en realidad es un boton y un modal por lo que se podría separar pero el css quedaría un poco complejo. 

usa display fixed asi que basta con importarlo en otro componente y va a aparecer.
se va a desplegar `props.children`  dentro de un container centrado

![BotonDelCalendario](https://user-images.githubusercontent.com/11396431/85197919-61071b80-b2b2-11ea-8d62-7f0589020a58.gif)
